### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - "4.1"
   - "4.0"
   - "0.12"
-  - "0.10"
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -336,12 +336,12 @@ This project is not done yet:
 
 ## MIT Licensed
 
-  [build-png]: https://secure.travis-ci.org/uber/idl.png
-  [build]: https://travis-ci.org/uber/idl
-  [cover-png]: https://coveralls.io/repos/uber/idl/badge.png
-  [cover]: https://coveralls.io/r/uber/idl
-  [dep-png]: https://david-dm.org/uber/idl.png
-  [dep]: https://david-dm.org/uber/idl
+  [build-png]: https://secure.travis-ci.org/uber-node/idl.png
+  [build]: https://travis-ci.org/uber-node/idl
+  [cover-png]: https://coveralls.io/repos/uber-node/idl/badge.png
+  [cover]: https://coveralls.io/r/uber-node/idl
+  [dep-png]: https://david-dm.org/uber-node/idl.png
+  [dep]: https://david-dm.org/uber-node/idl
   [npm-png]: https://nodei.co/npm/idl.png?stars&downloads
   [npm]: https://nodei.co/npm/idl
   [dominictarr/rc]: https://github.com/dominictarr/rc

--- a/get-dependencies.js
+++ b/get-dependencies.js
@@ -87,7 +87,7 @@ function resolveAllInstalledDependencies(thriftDir, callback) {
             );
 
             // Ignore any includes outside the ./idl/ folder
-            // See: https://github.com/uber/idl/pull/51
+            // See: https://github.com/uber-node/idl/pull/51
             if (absoluteInclude.indexOf(thriftDir) !== 0) {
                 return undefined;
             }

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "Andrew de Andrade <aandrade@uber.com>",
     "Jake Verbaten <jakev@uber.com>"
   ],
-  "repository": "git://github.com/uber/idl.git",
+  "repository": "git://github.com/uber-node/idl.git",
   "main": "index",
-  "homepage": "https://github.com/uber/idl",
+  "homepage": "https://github.com/uber-node/idl",
   "bin": {
     "idl": "bin/idl.js",
     "idl-daemon": "bin/idl-daemon.js"
   },
   "bugs": {
-    "url": "https://github.com/uber/idl/issues",
+    "url": "https://github.com/uber-node/idl/issues",
     "email": "aandrade@uber.com"
   },
   "dependencies": {
@@ -62,7 +62,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/uber/idl/raw/master/LICENSE"
+      "url": "http://github.com/uber-node/idl/raw/master/LICENSE"
     }
   ],
   "scripts": {

--- a/test/idl.js
+++ b/test/idl.js
@@ -70,7 +70,7 @@ TestCluster.test('run `idl init`', {
         ].join('\n');
 
         assert.equal(
-            local.idl['github.com'].uber.idl['idl.thrift'],
+            local.idl['github.com']['uber-node'].idl['idl.thrift'],
             expected,
             'Correct IDL file contents at the correct path'
         );

--- a/test/idl.js
+++ b/test/idl.js
@@ -802,7 +802,6 @@ TestCluster.test('run `idl update`', {
 
 TestCluster.test('run `idl update` with corrupt meta.json', {
 }, function t(cluster, assert) {
-
     var now = Date.now();
 
     series([
@@ -815,9 +814,9 @@ TestCluster.test('run `idl update` with corrupt meta.json', {
         if (err) {
             assert.ifError(err);
         }
-        var expected = 'Corrupt meta.json file: Unexpected end of input';
-        assert.equal(
-            data[2].stderr.message,
+        var expected = 'Corrupt meta.json file: Unexpected end of ';
+        assert.ok(
+            data[2].stderr.message.lastIndexOf(expected, 0) === 0,
             expected,
             'Warn user about corrupt meta'
         );


### PR DESCRIPTION
This change incorporates necessary fixes to get CI to pass after this project’s long run without changes.

- npm no longer supports Node 0.10, so we remove this version from CI.
- The repository location has changed. There are tests that depend on the the git origin.
- Addresses a breaking change in JSON reader library. The underlying library changed an error message, so this weakens the assertion on the error message.