### PR TITLE
Use shallow clone and fetch

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -885,7 +885,7 @@ function cloneRepository(cb) {
 
         var cwd = path.dirname(self.repoCacheLocation);
 
-        var command = 'git clone ' +
+        var command = 'git clone --depth 1 ' +
             self.repository + ' ' +
             self.repoCacheLocation;
         self.git(command, {
@@ -899,7 +899,7 @@ function pullRepository(cb) {
     var self = this;
 
     var cwd = self.repoCacheLocation;
-    var command = 'git fetch --all';
+    var command = 'git fetch -depth 1 ';
     self.git(command, {
         cwd: cwd,
         ignoreStderr: true


### PR DESCRIPTION
This change mitigates long running idl commands that are synchronizing all branches and tags with the remote registry/repository.

Reviewed as #70 