### PR TITLE
Avoid hash repo when unset allowing processArgs to catch invalid args

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -223,7 +223,7 @@ function IDL(opts) {
 
     self.logger = opts.logger || DebugLogtron('idl', opts.logOpts || {});
 
-    self.repoHash = sha1(self.repository);
+    self.repoHash = self.repository && sha1(self.repository) || '';
     self.repoCacheLocation = path.join(
         self.cacheDir, self.repoHash
     );


### PR DESCRIPTION
This restores `idl` to a working state where `idl version` can still be run when `repository` is not set.

Before:
```sh
$ idl version
crypto.js:70
  this._handle.update(data, encoding);
               ^

TypeError: Not a string or buffer
    at TypeError (native)
    at Hash.update (crypto.js:70:16)
    at sha1 (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/hasher.js:33:10)
    at new IDL (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/bin/idl.js:226:21)
    at IDL (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/bin/idl.js:202:16)
    at onCwd (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/bin/idl.js:126:9)
    at testDir (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/bin/idl.js:161:20)
    at hasIdl (/Users/r/.nvm/versions/node/v4.1.2/lib/node_modules/idl/bin/idl.js:173:17)
    at FSReqWrap.cb [as oncomplete] (fs.js:212:19)
```

After:
```
$ idl version
3.1.8
```