### PR TITLE
Correct pullRepository git fetch to proper depth arg, fix lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
-# unreleased
+# v3.2.0 (unreleased)
 
-- No changes yet.
+- Fixes a bug where IDL would fail to update the cache repository. (@dnathe4th)
 
 
 # v3.1.8 (2017-07-24)

--- a/bin/idl.js
+++ b/bin/idl.js
@@ -899,7 +899,7 @@ function pullRepository(cb) {
     var self = this;
 
     var cwd = self.repoCacheLocation;
-    var command = 'git fetch -depth 1 ';
+    var command = 'git fetch --depth 1 --no-tags';
     self.git(command, {
         cwd: cwd,
         ignoreStderr: true
@@ -910,7 +910,7 @@ function pullRepository(cb) {
             return cb(err);
         }
 
-        var command2 = 'git merge --ff-only origin/master';
+        var command2 = 'git reset --hard origin/master';
         self.git(command2, {
             cwd: cwd
         }, cb);

--- a/hasher.js
+++ b/hasher.js
@@ -57,7 +57,7 @@ function shasumFiles(dir, callback) {
                 return;
             }
             if (this.key && fileFilter(this.key)) {
-                filteredFiles[this.path.join("/")] = value;
+                filteredFiles[this.path.join('/')] = value;
             }
         });
 

--- a/meta-file.js
+++ b/meta-file.js
@@ -168,7 +168,7 @@ MetaFile.prototype.toJSON = function toJSON() {
 // sort object properties by their names in lexicographical order
 function sortObject(unsorted) {
     var sorted = {};
-    Object.keys(unsorted).sort().forEach(function(key) {
+    Object.keys(unsorted).sort().forEach(function forEachSort(key) {
         sorted[key] = unsorted[key];
     });
     return sorted;

--- a/test/lib/thrift-idl.js
+++ b/test/lib/thrift-idl.js
@@ -56,7 +56,7 @@ function thriftIdlWithIncludes(serviceName, includes) {
 function getIncludesTemplate(includes) {
     var includeTemplate = [];
     for (var i = 0; i < includes.length; i++) {
-        includeTemplate.push('include {' + i + '}')
+        includeTemplate.push('include {' + i + '}');
     }
     return template(includeTemplate.join('\n') + '\n', includes);
 }


### PR DESCRIPTION
NOTE: The hard reset to `origin/master` is required because there is no way for git to do a fast-forward merge with only a single commit fetched.