### PR TITLE
Stop publishing timestamp tags

### DIFF
--- a/git-commands.js
+++ b/git-commands.js
@@ -28,7 +28,6 @@ var gitexec = require('./git-process.js').exec;
 module.exports.addCommitTagAndPushToOrigin = addCommitTagAndPushToOrigin;
 module.exports.addFiles = addFiles;
 module.exports.commitWithMessage = commitWithMessage;
-module.exports.timestampTag = timestampTag;
 module.exports.pushToOriginWithTags = pushToOriginWithTags;
 
 function addCommitTagAndPushToOrigin(opts, callback) {
@@ -44,7 +43,6 @@ function addCommitTagAndPushToOrigin(opts, callback) {
         removeFiles.bind(ctx, opts.deletedFiles),
         updateFiles.bind(ctx),
         commitWithMessage.bind(ctx, opts.service, opts.version),
-        timestampTag.bind(ctx, opts.service, opts.timestamp),
         pushToOriginWithTags.bind(ctx)
     ], callback);
 }
@@ -89,18 +87,8 @@ function commitWithMessage(service, version, callback) {
     }, callback);
 }
 
-function timestampTag(service, currTime, callback) {
-    var command = 'git tag ' +
-        'v' + currTime.getTime() + ' ' +
-        '-am "' + currTime.toISOString() + ' ' + service + '"';
-    gitexec(command, {
-        cwd: this.cwd,
-        logger: this.logger
-    }, callback);
-}
-
 function pushToOriginWithTags(callback) {
-    var command = 'git push origin master --tags';
+    var command = 'git push origin master';
     gitexec(command, {
         cwd: this.cwd,
         logger: this.logger,

--- a/test/idl-daemon.js
+++ b/test/idl-daemon.js
@@ -118,14 +118,6 @@ TestCluster.test('run the idl-daemon', {
             'Correct thrift definition for D'
         );
 
-        var remotes = data.meta.remotes;
-        assert.equal(data.gittag, '' +
-            'v' + new Date(remotes['github.com/org/a'].time).getTime() + '\n' +
-            'v' + new Date(remotes['github.com/org/b'].time).getTime() + '\n' +
-            'v' + new Date(remotes['github.com/org/c'].time).getTime() + '\n' +
-            'v' + new Date(remotes['github.com/org/d'].time).getTime() + '\n'
-        );
-
         assert.end();
     }
 });
@@ -367,18 +359,6 @@ TestCluster.test('updating a remote', {
             thriftIdl('D'),
             'Correct thrift definition for D'
         );
-
-        var remotes = data.meta.remotes;
-        var tags = data.gittag.trim().split('\n');
-
-        assert.equal(tags[0], 'v' + new Date(remotes['github.com/org/a'].time)
-            .getTime());
-        assert.equal(tags[2], 'v' + new Date(remotes['github.com/org/c'].time)
-            .getTime());
-        assert.equal(tags[3], 'v' + new Date(remotes['github.com/org/d'].time)
-            .getTime());
-        assert.equal(tags[4], 'v' + new Date(remotes['github.com/org/b'].time)
-            .getTime());
 
         assert.end();
     }


### PR DESCRIPTION
These tags are superfluous and waste time on clone.