### PR TITLE
fix includes resolution for multi-file directories

### DIFF
--- a/get-dependencies.js
+++ b/get-dependencies.js
@@ -73,7 +73,8 @@ function resolveAllInstalledDependencies(thriftDir, callback) {
             var dir = this.path.slice(0, this.path.length - 1).join('/');
             var includes = parseIncludes(value);
             if (includes.length > 0) {
-                memo[dir] = [].concat(includes.map(pathToServiceName))
+                memo[dir] = (memo[dir] || [])
+                    .concat(includes.map(pathToServiceName))
                     .filter(removeUndef);
             }
         }

--- a/get-dependencies.js
+++ b/get-dependencies.js
@@ -49,8 +49,8 @@ function getIncludes(thriftDir, service, callback) {
     }
 }
 
-function removeUndef(n) {
-    return n !== undefined;
+function removeUndefAndDupes(n, idx, currArray) {
+    return n !== undefined && n !== currArray[idx + 1];
 }
 
 function resolveAllInstalledDependencies(thriftDir, callback) {
@@ -75,7 +75,8 @@ function resolveAllInstalledDependencies(thriftDir, callback) {
             if (includes.length > 0) {
                 memo[dir] = (memo[dir] || [])
                     .concat(includes.map(pathToServiceName))
-                    .filter(removeUndef);
+                    .sort()
+                    .filter(removeUndefAndDupes);
             }
         }
         return memo;

--- a/test/index.js
+++ b/test/index.js
@@ -22,3 +22,4 @@
 
 require('./idl-daemon.js');
 require('./idl.js');
+require('./unit/get-dependencies.js');

--- a/test/unit/get-dependencies.js
+++ b/test/unit/get-dependencies.js
@@ -99,11 +99,8 @@ test('getServiceDependenciesFromIncludes',
                 'github.com/b-team/baz',
                 'github.com/b-team/qux',
                 'github.com/company/common',
-                'github.com/company/common' // from a-team/otherthrift.thrift
             ];
 
-            expected.sort();
-            serviceDependencies.sort();
             assert.deepEqual(serviceDependencies, expected);
 
             assert.end();

--- a/test/unit/get-dependencies.js
+++ b/test/unit/get-dependencies.js
@@ -22,6 +22,7 @@
 
 var test = require('tape');
 var path = require('path');
+var mkdirp = require('mkdirp');
 var withFixtures = require('fixtures-fs');
 
 var thriftIdl = require('../lib/thrift-idl').thriftIdl;
@@ -73,6 +74,13 @@ var fixtures = {
     }
 };
 
+test('setup', function t(assert) {
+    // race-condition in fixtures-fs can cause mkdir to fail
+    // when mkdir /fixtures/idl is called before mkdir/fixtures
+    mkdirp.sync(fixturesPath);
+    assert.end();
+});
+
 test('getServiceDependenciesFromIncludes',
     withFixtures(fixturesPath, fixtures, function t(assert) {
         getDependencies(
@@ -94,6 +102,8 @@ test('getServiceDependenciesFromIncludes',
                 'github.com/company/common' // from a-team/otherthrift.thrift
             ];
 
+            expected.sort();
+            serviceDependencies.sort();
             assert.deepEqual(serviceDependencies, expected);
 
             assert.end();

--- a/test/unit/get-dependencies.js
+++ b/test/unit/get-dependencies.js
@@ -24,7 +24,7 @@ var test = require('tape');
 var path = require('path');
 var withFixtures = require('fixtures-fs');
 
-var thriftIdl = require('../lib/thrift-idl');
+var thriftIdl = require('../lib/thrift-idl').thriftIdl;
 var getDependencies = require('../../get-dependencies');
 
 var fixturesPath = path.resolve(__dirname, '../fixtures');
@@ -39,6 +39,10 @@ var fixtures = {
                         'include "../../b-team/qux/qux.thrift"',
                         'include "../../company/common/common.thrift"',
                         thriftIdl('Foo')
+                    ].join('\n'),
+                    // multiple files in the same folder
+                    'otherfoo.thrift': [
+                        'include "../../company/common/common.thrift"'
                     ].join('\n')
                 },
                 bar: {
@@ -72,7 +76,8 @@ var fixtures = {
 test('getServiceDependenciesFromIncludes',
     withFixtures(fixturesPath, fixtures, function t(assert) {
         getDependencies(
-            path.resolve(__dirname, '../fixtures/idl/github.com/a-team/foo'),
+            path.resolve(__dirname, '../fixtures/idl'),
+            'github.com/a-team/foo',
             onIncludes
         );
 
@@ -85,7 +90,8 @@ test('getServiceDependenciesFromIncludes',
                 'github.com/a-team/bar',
                 'github.com/b-team/baz',
                 'github.com/b-team/qux',
-                'github.com/company/common'
+                'github.com/company/common',
+                'github.com/company/common' // from a-team/otherthrift.thrift
             ];
 
             assert.deepEqual(serviceDependencies, expected);


### PR DESCRIPTION
If a directory has multiple thrift files in a directory, i.e.
```
github.com/a-team/foo
     foo.thrift
     otherfoo.thrift
```
Then the `getIncludes` function only gathers the dependencies of the last file read and processed. This diff accumulates all of the sub-includes for this type of directory.