### PR TITLE
add git debug output to git-commands.js

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -222,6 +222,7 @@ function IDL(opts) {
     self.cwd = opts.cwd || process.cwd();
 
     self.logger = opts.logger || DebugLogtron('idl', opts.logOpts || {});
+    self.debugGit = opts.debugGit;
 
     self.repoHash = self.repository && sha1(self.repository) || '';
     self.repoCacheLocation = path.join(
@@ -786,7 +787,8 @@ function publish(cb) {
             service: service,
             timestamp: self.meta.time(),
             cwd: self.repoCacheLocation,
-            logger: self.logger
+            logger: self.logger,
+            debugGit: self.debugGit
         }, done);
 
         function getFilepath(filename) {

--- a/git-commands.js
+++ b/git-commands.js
@@ -35,7 +35,8 @@ function addCommitTagAndPushToOrigin(opts, callback) {
 
     var ctx = {
         cwd: opts.cwd,
-        logger: opts.logger
+        logger: opts.logger,
+        debugGit: opts.debugGit
     };
 
     series([
@@ -51,7 +52,8 @@ function addFiles(files, callback) {
     var command = 'git add ' + files.join(' ');
     gitexec(command, {
         cwd: this.cwd,
-        logger: this.logger
+        logger: this.logger,
+        debugGit: this.debugGit
     }, callback);
 }
 
@@ -62,7 +64,8 @@ function removeFiles(files, callback) {
     var command = 'git rm ' + files.join(' ');
     gitexec(command, {
         cwd: this.cwd,
-        logger: this.logger
+        logger: this.logger,
+        debugGit: this.debugGit
     }, callback);
 }
 
@@ -70,7 +73,8 @@ function updateFiles(callback) {
     var command = 'git add --update';
     gitexec(command, {
         cwd: this.cwd,
-        logger: this.logger
+        logger: this.logger,
+        debugGit: this.debugGit
     }, callback);
 }
 
@@ -83,7 +87,8 @@ function commitWithMessage(service, version, callback) {
     var command = 'git commit ' + '-m "' + message + '"';
     gitexec(command, {
         cwd: this.cwd,
-        logger: this.logger
+        logger: this.logger,
+        debugGit: this.debugGit
     }, callback);
 }
 
@@ -92,6 +97,7 @@ function pushToOriginWithTags(callback) {
     gitexec(command, {
         cwd: this.cwd,
         logger: this.logger,
+        debugGit: this.debugGit,
         ignoreStderr: true
     }, callback);
 }


### PR DESCRIPTION
passing the debugGit flag also to gitspawn calls in git-commands.js so that we get the full log of git interactions when debugging.

Let me know if you would like to see more refactoring inside git-commands.js. One approach would be to pass the Git object created in idl.js to git-commands.js so that we do not have to replicate the option setting time and again. 

Thanks,
Pascal

