### PR TITLE
Fix a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ project.
 
 Example:
 
-    $ idl fetch github.com:/foo/bar
+    $ idl fetch github.com/foo/bar
     $
 
 #### `idl update`


### PR DESCRIPTION
Fixed a typo in the readme. There should no colon(:) in the command.