### PR TITLE
Nix superfluous tag checkout.

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -470,27 +470,10 @@ function fetchFromMeta(cb) {
         )
     });
 
-    localMeta.readFile(onReadLocalMeta);
+    var services = Object.keys(localMeta.toJSON().remotes)
+        .map(makeFetchServiceThunk);
 
-    function onReadLocalMeta(err) {
-        if (err) {
-            return cb(err);
-        }
-
-        var idlVersion = localMeta.toJSON().version;
-        self.checkoutRef('v' + idlVersion, onCheckoutRegistryTag);
-    }
-
-    function onCheckoutRegistryTag(err) {
-        if (err) {
-            return cb(err);
-        }
-
-        var services = Object.keys(localMeta.toJSON().remotes)
-            .map(makeFetchServiceThunk);
-
-        parallel(services, cb);
-    }
+    parallel(services, cb);
 
     function makeFetchServiceThunk(service) {
         return fetch.bind(self, service);


### PR DESCRIPTION
Tests pass when I remove what appears to be a superfluous checkout of the version timestamp tag for the current project’s idl/meta.json. I am not sure this is correct, since I’m not sure why this was here in the first place, but my intuition is that each individual service fetch is independent, and does not depend on this initial checkout.

Is there a test I can add that would illustrate that this is a breaking change?

The purpose of this review is to ask @raynos @malandrew what the intended purpose of this line was, and whether I can safely remove it.

The reason I’m asking is that this would mitigate a bug I introduced when I released a change that stopped pushing a timestamp tag for every published commit. I may have to revert that change and backfill tags, but if they are unnecessary, this alternative is better.

I may be able to rewrite the relevant behavior of `idl` using git plumbing commands, but until then I’m looking for small fixes. From first principles, I believe version tags are unnecessary.