### PR TITLE
Remove dependence on pty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "6.11"
   - "4.1"
   - "4.0"
+  - "0.12"
 addons:
   apt:
     sources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# (unreleased)
+
+- No changes yet.
+
 # v3.1.11 (2018-01-25)
 
 - Fixes fetch and update in the absence of version tags. Both of these commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 
 # (unreleased)
 
-- No changes yet.
+- Remove dependency on a pty. We no longer need to scan the pty output
+  for authentication warnings. The pty module does not support Node.js versions
+  we still use, dating back to 0.10.
 
 # v3.1.11 (2018-01-25)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -659,11 +659,6 @@
         "es5-ext": "0.10.30"
       }
     },
-    "extend": {
-      "version": "1.2.1",
-      "resolved": "https://unpm.uberinternal.com/extend/-/extend-1.2.1.tgz",
-      "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
-    },
     "fast-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://unpm.uberinternal.com/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
@@ -1433,26 +1428,6 @@
       "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
       "dev": true
     },
-    "nan": {
-      "version": "2.3.5",
-      "resolved": "https://unpm.uberinternal.com/nan/-/nan-2.3.5.tgz",
-      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg="
-    },
-    "node-pty": {
-      "version": "0.7.4",
-      "resolved": "https://unpm.uberinternal.com/node-pty/-/node-pty-0.7.4.tgz",
-      "integrity": "sha512-WxMY1BsGcHJ2Z2qWpYL7QbfOSnkkCzV0H/9+dJ7uQEIJyz0A4fVBLymswBCTc7RoweY5ingib2gNvf87KvJxuA==",
-      "requires": {
-        "nan": "2.8.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://unpm.uberinternal.com/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-        }
-      }
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://unpm.uberinternal.com/nopt/-/nopt-3.0.6.tgz",
@@ -1577,15 +1552,6 @@
       "resolved": "https://unpm.uberinternal.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
-    },
-    "pty.js": {
-      "version": "0.3.1",
-      "resolved": "https://unpm.uberinternal.com/pty.js/-/pty.js-0.3.1.tgz",
-      "integrity": "sha1-gfW+0zLW5eeraFaI0boDc0ENUbU=",
-      "requires": {
-        "extend": "1.2.1",
-        "nan": "2.3.5"
-      }
     },
     "rc": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "graceful-fs": "^4.1.9",
     "minimist": "1.1.1",
     "mkdirp": "0.5.1",
-    "node-pty": "^0.7.4",
     "once": "^1.3.2",
     "pascal-case": "^1.1.1",
     "process": "0.11.1",


### PR DESCRIPTION
We discovered in production that node-pty is not compatible with versions of
Node.js dating back to 0.10 or 0.12. We also no longer need this since
we preauthenticate, so we don't get PAM prompts anymore.
This change removes the pty.